### PR TITLE
URL field + code style

### DIFF
--- a/build.py
+++ b/build.py
@@ -272,7 +272,7 @@ if __name__ == '__main__':
     except:
         pass
 
-    print "Start build..."
+    print("Start build...")
 
     events = get_events_from_folder(main_folder)
     build_index_page(main_folder, events)
@@ -281,4 +281,4 @@ if __name__ == '__main__':
     add_to_build(main_folder, 'styles')
     add_to_build(main_folder, 'assets')
 
-    print "Build finished."
+    print("Build finished.")

--- a/build.py
+++ b/build.py
@@ -30,7 +30,7 @@ def add_to_build(main_folder, folder):
     shutil.copytree(src, dest)
 
 
-# Shortcut for python file creation.
+# Shortcut for python file creation.
 def write_file(folder, file_name, content):
     mkdir_p(folder)
     file = open(os.path.join(folder, file_name), 'w')
@@ -38,7 +38,7 @@ def write_file(folder, file_name, content):
     file.close()
 
 
-# File data extraction
+# File data extraction
 
 
 # Transform event file into a dictionary.

--- a/build.py
+++ b/build.py
@@ -204,6 +204,7 @@ DTSTART:$start_ical
 DTEND: $end_ical
 LOCATION: $place - $address
 SUMMARY:$name
+URL:$link
 END:VEVENT"""
 
 ical_footer_template = """END:VCALENDAR"""

--- a/build.py
+++ b/build.py
@@ -67,7 +67,7 @@ def get_events_from_folder(main_folder):
 
         if folder is not event_folder:
             country = os.path.basename(folder)
-            if not country in events:
+            if country not in events:
                 events[country] = []
 
             for file in files:

--- a/build_test.py
+++ b/build_test.py
@@ -117,6 +117,7 @@ DTSTART:20170204T100000Z
 DTEND: 20170205T180000Z
 LOCATION: ULB - Avenue Franklin Roosevelt 50 1050 Bruxelles
 SUMMARY:FOSDEM' 17
+URL:https://fosdem.org/
 END:VEVENT''' % now.strftime(build.ICAL_DATE_FORMAT))
 
     def test_build_ical_files(self):

--- a/build_test.py
+++ b/build_test.py
@@ -52,7 +52,7 @@ class TestBuild(unittest.TestCase):
 
 
     def test_build_header(self):
-    	header = open(os.path.join(partial_folder, 'header.html')).read()
+        header = open(os.path.join(partial_folder, 'header.html')).read()
         self.assertEqual(build.build_header(partial_folder), header)
 
 

--- a/build_test.py
+++ b/build_test.py
@@ -33,8 +33,7 @@ class TestBuild(unittest.TestCase):
     def test_get_events_from_folder(self):
         base_folder = os.path.join(main_folder, 'fixtures')
         events = build.get_events_from_folder(base_folder)
-        countries = events.keys()
-        countries.sort()
+        countries = sorted(events.keys())
         self.assertEqual(['belgium', 'france', 'germany'], countries)
 
         event = events['belgium'][0]
@@ -110,7 +109,7 @@ X-WR-CALNAME:Hacker Events in belgium""")
         event = build.get_event_from_file(folder, '20170204-fosdem.yml')
         event['country'] = 'belgium'
         now = datetime.datetime.now()
-        self.assertEquals(build.get_ical_event(event, now), '''BEGIN:VEVENT
+        self.assertEqual(build.get_ical_event(event, now), '''BEGIN:VEVENT
 UID: 20170204-fosdem
 DTSTAMP:%s
 DTSTART:20170204T100000Z


### PR DESCRIPTION
Hello,

I added the URL field to the ICAL rendering to be able to open the event website directly from my calendar. It works and pass the tests (in whose i added URL field).

I also fixed some code style issues and replaced `print "foo"` by `print("foo")`  to start to be compatible with Python3 (`build.py` works with Python3 but `build_test.py` not completely).
