### PR TITLE
Minor fixes: repo url and empty country render

### DIFF
--- a/build.py
+++ b/build.py
@@ -71,7 +71,7 @@ def get_events_from_folder(main_folder):
             if country not in events:
                 events[country] = []
 
-            for file in files:
+            for file in filter(lambda file: file[-4:] == '.yml', files):
                 event = get_event_from_file(folder, file)
                 event['country'] = country
                 end = datetime.datetime.strptime(event['end'], DATE_FORMAT)

--- a/build.py
+++ b/build.py
@@ -164,16 +164,17 @@ def build_event_list(events):
     content.append('</header>')
     for country in countries:
 
-        template = string.Template(country_header_template)
-        content.append(template.substitute({
-            'country': country,
-            'country_capitalize': country.capitalize(),
-        }))
+        if len(events[country]) > 0:
+            template = string.Template(country_header_template)
+            content.append(template.substitute({
+                'country': country,
+                'country_capitalize': country.capitalize(),
+            }))
 
-        for event in reversed(events[country]):
-            content.append(get_html_event(event))
+            for event in reversed(events[country]):
+                content.append(get_html_event(event))
 
-        content.append('</div>')
+            content.append('</div>')
 
     return '\n'.join(content)
 

--- a/build_test.py
+++ b/build_test.py
@@ -34,7 +34,7 @@ class TestBuild(unittest.TestCase):
         base_folder = os.path.join(main_folder, 'fixtures')
         events = build.get_events_from_folder(base_folder)
         countries = sorted(events.keys())
-        self.assertEqual(['belgium', 'france', 'germany'], countries)
+        self.assertEqual(['belgium', 'china', 'france', 'germany'], countries)
 
         event = events['belgium'][0]
         self.assertEqual(event['name'], "FOSDEM' 17")
@@ -88,7 +88,6 @@ class TestBuild(unittest.TestCase):
 </p></div></div>""")
 
     def test_build_event_list(self):
-
         pass
 
     def test_build_index_page(self):

--- a/fixtures/events/china/.gitignore
+++ b/fixtures/events/china/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/partials/header.html
+++ b/partials/header.html
@@ -42,5 +42,5 @@
     <section class="about">    
         <p class="contribute">This website is free and open source. See your
         favorite event listed here by 
-        <a href="https://github.com/frankrousseau/hackerevents">contributing</a>!</p>
+        <a href="https://github.com/hackerevents/hackerevents">contributing</a>!</p>
     </section>


### PR DESCRIPTION
This PR fixes two problems:

* The URL for the Github repo given in introduction is wrong (frankrousseau/hackerevents instead of hackerevents/hackerevents).
* When a country has no event, it is rendered. Which makes the page ugly.